### PR TITLE
Add cmake Doxygen function to create project documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ project_options()
 add_library( Hack::project_warnings ALIAS project_warnings )
 add_library( Hack::project_options ALIAS project_options )
 
+include( Doxygen )
+Enable_Doxygen()
 
 if( PROJECT_IS_TOP_LEVEL )
    include( CTest )
@@ -66,6 +68,4 @@ if( PROJECT_IS_TOP_LEVEL )
 	add_subdirectory( tests )
 #	add_subdirectory( packaging )
 endif() 
-
-
 

--- a/cmake/Doxygen.cmake
+++ b/cmake/Doxygen.cmake
@@ -1,0 +1,38 @@
+find_package( Doxygen REQUIRED )
+
+include( FetchContent )
+
+FetchContent_Declare( doxygen-awesome-css
+  GIT_REPOSITORY
+    https://github.com/jothepro/doxygen-awesome-css.git
+  GIT_TAG
+    v2.3.3
+)
+
+FetchContent_MakeAvailable( doxygen-awesome-css )
+
+
+# Generate Project-Wide Docs
+function( Enable_Doxygen )
+   
+   set( NAME                           "doxygen-${target}" )
+   set( DOXYGEN_HTML_OUTPUT            ${PROJECT_BINARY_DIR} )
+   set( DOXYGEN_GENERATE_HTML          YES )
+   set( DOXYGEN_GENERATE_TREEVIEW      YES )
+   set( DOXYGEN_HAVE_DOT               YES )
+   set( DOXYGEN_DOT_IMAGE_FORMAT       svg )
+   set( DOXYGEN_DOT_TRANSPARENT        YES )
+   set( DOXYGEN_CALLER_GRAPH           YES ) 
+   set( DOXYGEN_CALL_GRAPH             YES )
+   set( DOXYGEN_EXTRACT_ALL            YES )
+   set( DOXYGEN_HTML_EXTRA_STYLESHEET  ${doxygen-awesome-css_SOURCE_DIR}/doxygen-awesome.css )
+
+   doxygen_add_docs( doxygen-docs 
+      ALL
+      ${PROJECT_SOURCE_DIR}
+      COMMENT "Generating documentation - entry file: ${CMAKE_CURRENT_BINARY_DIR}/html/index.html"
+   )
+
+   message( STATUS "Adding `doxygen-docs` target that builds project documentation." )
+   
+endfunction()


### PR DESCRIPTION
Add cmake function `Enable_Doxygen` to generate project documentation.
Add `doxygen-docs` target that builds project documentation.